### PR TITLE
Fix InventoryWindow comment formatting

### DIFF
--- a/src/ui/InventoryWindow.java
+++ b/src/ui/InventoryWindow.java
@@ -51,7 +51,7 @@ public class InventoryWindow extends JFrame {
         btns.add(refreshBtn);
 
         add(btns, BorderLayout.NORTH);
-        add(new JScrollPane(table), BorderLayout.CENTER);   // scroll bar (the whole area, draw scroll bar according to how many)
+        add(new JScrollPane(table), BorderLayout.CENTER);   // scroll bar for the entire table area
 
         // First load
         reload();


### PR DESCRIPTION
## Summary
- replace the split inline comment in `InventoryWindow` with a concise explanation of the scroll pane

## Testing
- javac -d build/classes $(find src -name "*.java")

------
https://chatgpt.com/codex/tasks/task_e_68ccf2f369c08330b35737ba192328cb